### PR TITLE
Configure App wrong key in bootstrap tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -39,7 +39,7 @@ Configure::write('App', [
 	'baseUrl' => false,
 	'dir' => 'src',
 	'webroot' => 'webroot',
-	'www_root' => APP . 'webroot',
+	'wwwRoot' => APP . 'webroot',
 	'fullBaseUrl' => 'http://localhost',
 	'imageBaseUrl' => 'img/',
 	'jsBaseUrl' => 'js/',


### PR DESCRIPTION
In the `Configure::write('App', [...])` call, the key `www_root` is wrong. It should be `wwwRoot`.

Ref : https://github.com/cakephp/cakephp/blob/3.0/tests/bootstrap.php#L75
